### PR TITLE
Bump Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: ${{ matrix.os_type }}:${{ matrix.os_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: sources
       - name: set version

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
         arch: [ x86_64 ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: sources
       - name: set version
@@ -58,7 +58,7 @@ jobs:
       - name: open PR
         if: env.SKIP_BUILD != 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           path: sources
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the latest action versions, mostly to bump to the latest node versions.